### PR TITLE
Add the missing `TransactionDetails` type

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -425,11 +425,14 @@ impl Client {
     /// let client = Client::new("http://seed-host.com:8648".to_string());
     /// let result = client.get_transaction_by_hash("465a63b73aa0b9b54b777be9a585ea00b367a17898ad520e1f22cb2c986ff554");
     /// ```
-    pub fn get_transaction_by_hash(&self, transaction_hash: &str) -> Result<Transaction, Error> {
+    pub fn get_transaction_by_hash(
+        &self,
+        transaction_hash: &str,
+    ) -> Result<TransactionDetails, Error> {
         let params = &[serde_json::to_value(transaction_hash)?];
         self.agent
             .send_request(&self.agent.build_request("getTransactionByHash", params))
-            .and_then(|res| res.into_result::<Transaction>())
+            .and_then(|res| res.into_result::<TransactionDetails>())
     }
 
     /// Returns the receipt of a transaction by transaction hash.
@@ -484,14 +487,14 @@ impl Client {
         &self,
         address: &str,
         amount: u16,
-    ) -> Result<Vec<Transaction>, Error> {
+    ) -> Result<Vec<TransactionDetails>, Error> {
         let params = &[
             serde_json::to_value(address)?,
             serde_json::to_value(amount)?,
         ];
         self.agent
             .send_request(&self.agent.build_request("getTransactionsByAddress", params))
-            .and_then(|res| res.into_result::<Vec<Transaction>>())
+            .and_then(|res| res.into_result::<Vec<TransactionDetails>>())
     }
 
     /// Returns instructions to mine the next block. This will consider pool instructions when connected to a pool.

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -169,6 +169,25 @@ pub struct Transaction {
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+pub struct TransactionDetails {
+    pub hash: String,
+    pub block_hash: String,
+    pub block_number: u32,
+    pub timestamp: u32,
+    pub confirmations: u32,
+    pub from: String,
+    pub from_address: String,
+    pub to: String,
+    pub to_address: String,
+    pub value: u64,
+    pub fee: u64,
+    pub data: Option<String>,
+    pub proof: Option<String>,
+    pub flags: u8,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct TransactionReceipt {
     pub transaction_hash: String,
     pub transaction_index: i32,


### PR DESCRIPTION
- Add the missing `TransactionDetails` type that is returned in the methods to get transactions by address or a transaction by hash.
- Change the `flags` member type in `Transaction` from `u32` to `u8` since it is actually a `u8`.