### PR TITLE
Add new RPC methods

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -486,6 +486,34 @@ impl Client {
         self.agent.request("getTransactionByHash", params).await
     }
 
+    /// Returns the information about a transaction requested by transaction hash.
+    ///
+    /// # Arguments
+    ///
+    /// * `String`: Hash of a transaction
+    ///
+    /// # Returns
+    ///
+    /// A transaction object or `null` when no transaction was found.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use nimiq_rpc::Client;
+    /// use url::Url;
+    /// # tokio_test::block_on(async {
+    /// let client = Client::new(Url::parse("http://seed-host.com:8648").unwrap());
+    /// let result = client.get_transaction_by_hash_2("465a63b73aa0b9b54b777be9a585ea00b367a17898ad520e1f22cb2c986ff554").await;
+    /// # })
+    /// ```
+    pub async fn get_transaction_by_hash_2(
+        &self,
+        transaction_hash: &str,
+    ) -> Result<TransactionDetails2, Error> {
+        let params = rpc_params![transaction_hash];
+        self.agent.request("getTransactionByHash2", params).await
+    }
+
     /// Returns the receipt of a transaction by transaction hash.
     /// `Note` That the receipt is not available for pending transactions.
     ///

--- a/src/client.rs
+++ b/src/client.rs
@@ -197,6 +197,33 @@ impl Client {
         self.agent.request("getAccount", params).await
     }
 
+    /// Returns an Accounts tree chunk.
+    ///
+    /// # Arguments
+    ///
+    /// * `String`: Block hash on which the accounts tree chunk is going to be retrieved.
+    /// * `String`: Start prefix for the accounts tree chunk to retrieve.
+    ///
+    /// # Returns
+    ///
+    /// An Accounts tree chunk containing the tail prefix and the length of the chunk.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use nimiq_rpc::Client;
+    /// let client = Client::new("http://seed-host.com:8648".to_string());
+    /// let result = client.get_accounts_tree_chunk("14c91f6d6f3a0b62271e546bb09461231ab7e4d1ddc2c3e1b93de52d48a1da87", "").await;
+    /// ```
+    pub async fn get_accounts_tree_chunk(
+        &self,
+        block_hash: &str,
+        start_prefix: &str,
+    ) -> Result<AccountsTreeChunk, Error> {
+        let params = rpc_params![block_hash, start_prefix];
+        self.agent.request("getAccountsTreeChunk", params).await
+    }
+
     /// Returns the balance of the account of given address.
     ///
     /// # Arguments

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -203,6 +203,29 @@ pub struct TransactionDetails {
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+pub struct TransactionDetails2 {
+    pub hash: String,
+    pub block_hash: String,
+    pub block_number: u32,
+    pub timestamp: u32,
+    pub confirmations: u32,
+    pub from: String,
+    pub from_address: String,
+    pub from_type: u8,
+    pub to: String,
+    pub to_type: u8,
+    pub to_address: String,
+    pub value: u64,
+    pub fee: u64,
+    pub data: Option<String>,
+    pub proof: Option<String>,
+    pub flags: u8,
+    pub validity_start_height: u32,
+    pub network_id: u8,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct TransactionReceipt {
     pub transaction_hash: String,
     pub transaction_index: i32,

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -56,6 +56,19 @@ pub struct HTLCAccount {
 }
 
 #[derive(Clone, Debug, Deserialize)]
+pub struct AccountsTreeChunk {
+    pub nodes: Vec<AccountsTreeNode>,
+    pub proof: String,
+    pub tail: String,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct AccountsTreeNode {
+    pub prefix: String,
+    pub account: Account,
+}
+
+#[derive(Clone, Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Block {
     pub number: u32,

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -188,6 +188,21 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn get_transaction_by_hash_2() {
+        let client = client();
+        assert_eq!(
+            client
+                .get_transaction_by_hash_2(
+                    "465a63b73aa0b9b54b777be9a585ea00b367a17898ad520e1f22cb2c986ff554"
+                )
+                .await
+                .unwrap()
+                .block_hash,
+            "dfe7d166f2c86bd10fa4b1f29cd06c13228f893167ce9826137c85758645572f"
+        );
+    }
+
+    #[tokio::test]
     async fn get_transaction_receipt() {
         let client = client();
         assert_eq!(

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -46,6 +46,18 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn get_accounts_tree_chunk() {
+        let client = client();
+        client
+            .get_accounts_tree_chunk(
+                "A9284B441B56E93DE62F557414CC9B850BAD2BD30CF84B013CFE2EF6E11B6DA6",
+                "",
+            )
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
     async fn get_block_by_hash() {
         let client = client();
         assert_eq!(


### PR DESCRIPTION
Add new RPC methods added in `core-js` v0.1.6.2:
- Add new method for getting a transaction by hash with more transaction details (`get_transaction_by_hash_2`) with its respective test.
- Add new method for getting an accounts tree chunk with its respective test.